### PR TITLE
build: Make telemetry optional

### DIFF
--- a/DataSpace/asgi.py
+++ b/DataSpace/asgi.py
@@ -14,8 +14,9 @@ from django.core.asgi import get_asgi_application
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "DataSpace.settings")
 
 # Initialize OpenTelemetry before application
-from api.telemetry import setup_telemetry
+if os.getenv("TELEMETRY_URL"):
+    from api.telemetry import setup_telemetry
 
-setup_telemetry()  # Initialize telemetry for ASGI application
+    setup_telemetry()  # Initialize telemetry for ASGI application
 
 application = get_asgi_application()

--- a/DataSpace/wsgi.py
+++ b/DataSpace/wsgi.py
@@ -12,8 +12,9 @@ from django.core.wsgi import get_wsgi_application
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "DataSpace.settings")
 
 # Initialize OpenTelemetry before application
-from api.telemetry import setup_telemetry
+if os.getenv("TELEMETRY_URL"):
+    from api.telemetry import setup_telemetry
 
-setup_telemetry()  # Initialize telemetry for production application
+    setup_telemetry()  # Initialize telemetry for production application
 
 application = get_wsgi_application()

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -111,6 +111,7 @@ services:
     image: docker.elastic.co/elasticsearch/elasticsearch:7.16.2
     container_name: telemetry_elasticsearch
     restart: always
+    profiles: ["telemetry"]
     ulimits:
       memlock:
         soft: -1
@@ -140,6 +141,7 @@ services:
   kibana:
     image: docker.elastic.co/kibana/kibana:7.16.2
     container_name: kibana
+    profiles: ["telemetry"]
     environment:
       ELASTICSEARCH_URL: "http://telemetry_elasticsearch:9200"
       ELASTICSEARCH_HOSTS: '["http://telemetry_elasticsearch:9200"]'
@@ -155,6 +157,7 @@ services:
   apm-server:
     image: docker.elastic.co/apm/apm-server:7.16.2
     container_name: apm-server
+    profiles: ["telemetry"]
     user: apm-server
     restart: always
     command:
@@ -199,6 +202,7 @@ services:
   otel-collector:
     image: otel/opentelemetry-collector:latest
     container_name: otel-collector
+    profiles: ["telemetry"]
     restart: always
     command: "--config=/etc/otel-collector-config.yaml"
     volumes:


### PR DESCRIPTION
Start telemetry services with:

docker compose --profile telemetry up

For development (and perhaps some users), telemetry is not needed.